### PR TITLE
Remove default value from external key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,6 @@ export class SequelizeRevision {
             this.options.revisionAttribute,
             {
               type: DataTypes.INTEGER,
-              defaultValue: 0,
             }
           );
         } catch (err) {


### PR DESCRIPTION
BREAKING CHANGE: default value is no longer set for external key for migrations